### PR TITLE
Fixes non-inline functions resulting in an object named "int64" being created

### DIFF
--- a/gml/std/haxe/Int64.hx
+++ b/gml/std/haxe/Int64.hx
@@ -7,7 +7,7 @@ import haxe.Int32;
  * Conveniently, Int type in GM is already 64-bit.
  * @author YellowAfterlife
  */
-@:hintType("int64") @:native("int64")
+@:hintType("int64") @:native("hx_int64")
 abstract Int64(__Int64) {
 	public inline function copy():Int64 return this;
 	


### PR DESCRIPTION
Some int64 functions are not inlined, and using them results in a global struct called `int64` being created.