### PR TITLE
feat: quote struct keys

### DIFF
--- a/sf/SfConfig.hx
+++ b/sf/SfConfig.hx
@@ -149,6 +149,9 @@ class SfConfig extends SfConfigImpl {
 	/** Should we include `/// @typedef` for GMEdit? **/
 	public var jsDocTypeDefs:Bool = bool("sfgml-jsdoc-typedefs", true);
 	
+  /** Should we generate { "key": v } instead of { key: v } for structures?  **/
+	public var quoteStructKeys:Bool = bool("sfgml-quote-struct-keys", false);
+
 	public function new() {
 		super();
 		instanceof = true;

--- a/sf/SfGenerator.hx
+++ b/sf/SfGenerator.hx
@@ -668,13 +668,11 @@ class SfGenerator extends SfGeneratorImpl {
 								printf(r, ",\n");
 							} else r.addComma();
 						}
+
 						var name = pairs[i].name;
             var key = "%s:`";
-            if(sfConfig.quoteStructKeys){
-              key = '"%s":`';
-            }  
-          
-						printf(r, key, rxValidName.match(name) ? name : haxe.Json.stringify(name));
+            var value = rxValidName.match(name) && !sfConfig.quoteStructKeys ? name : haxe.Json.stringify(name);
+						printf(r, key, value);
 						r.addExpr(pairs[i].expr, SfPrintFlags.ExprWrap);
 					}
 					if (lineSep) {

--- a/sf/SfGenerator.hx
+++ b/sf/SfGenerator.hx
@@ -671,7 +671,7 @@ class SfGenerator extends SfGeneratorImpl {
 						var name = pairs[i].name;
             var key = "%s:`";
             if(sfConfig.quoteStructKeys){
-              key = "\"%s\":`";
+              key = '"%s":`';
             }  
           
 						printf(r, key, rxValidName.match(name) ? name : haxe.Json.stringify(name));

--- a/sf/SfGenerator.hx
+++ b/sf/SfGenerator.hx
@@ -669,7 +669,12 @@ class SfGenerator extends SfGeneratorImpl {
 							} else r.addComma();
 						}
 						var name = pairs[i].name;
-						printf(r, "%s:`", rxValidName.match(name) ? name : haxe.Json.stringify(name));
+            var key = "%s:`";
+            if(sfConfig.quoteStructKeys){
+              key = "\"%s\":`";
+            }  
+          
+						printf(r, key, rxValidName.match(name) ? name : haxe.Json.stringify(name));
 						r.addExpr(pairs[i].expr, SfPrintFlags.ExprWrap);
 					}
 					if (lineSep) {


### PR DESCRIPTION
Currently struct keys are emitted without quotes.
This causes invalid/problematic fields when a key matches a GameMaker keyword such as `end`, `then`, `if`, etc.

<img width="480" height="284" alt="image" src="https://github.com/user-attachments/assets/3fb314fd-0097-46a2-9d43-c2f9c71ae651" />
<img width="389" height="221" alt="image" src="https://github.com/user-attachments/assets/b4f55111-0f1e-4f32-b9d2-6204e241ed60" />


## Proposed Solution

Introduce a new config option: `sfgml-quote-struct-keys`

When enabled, all generated struct keys should be wrapped in quotes.
<img width="370" height="209" alt="image" src="https://github.com/user-attachments/assets/882aa331-ddbc-4d44-b1c1-4aeac4a32ed1" />

### Important Note

This only affects struct declaration/output generation.
It does not solve access issues when using dot notation: `struct.field`